### PR TITLE
devcontainer.jsonにClaude設定ファイルのマウントを追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
         "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
-        "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached,readonly"
+        "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.claude/settings.json,target=/home/${localEnv:USER}/.claude/settings.json,type=bind,consistency=cached,readonly"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {


### PR DESCRIPTION
## Summary

- Claude Code設定ファイル(settings.json)をコンテナ内にマウントするように設定を追加
- 開発環境でClaude Codeの設定を利用できるように改善

## 変更内容

- `.devcontainer/devcontainer.json`に`~/.claude/settings.json`のマウント設定を追加
- 既存のCLAUDE.mdファイルのマウントと同様にreadonlyで設定

## Test plan

- [x] devcontainerを再ビルドして正常に起動することを確認
- [x] コンテナ内でClaude設定ファイルが正しくマウントされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)