### PR TITLE
feat(devcontainer): ClineディレクトリのマウントをdevcontainerJSONに追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
         "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached,readonly",
-        "source=${localEnv:HOME}/.claude/settings.json,target=/home/${localEnv:USER}/.claude/settings.json,type=bind,consistency=cached,readonly"
+        "source=${localEnv:HOME}/.claude/settings.json,target=/home/${localEnv:USER}/.claude/settings.json,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/Documents/Cline,target=/home/${localEnv:USER}/Cline,type=bind,consistency=cached,readonly"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {


### PR DESCRIPTION
## 変更内容の概要
VS Code Dev Container環境でClineディレクトリへのアクセスを可能にするため、`.devcontainer/devcontainer.json`に読み取り専用マウントを追加しました。

## 変更の目的
- Cline AI開発ツールとの連携を容易にする
- 開発環境でClineディレクトリのコンテンツにアクセスできるようにする

## 変更詳細
- `~/Documents/Cline`を`/home/${localEnv:USER}/Cline`にマウント
- 読み取り専用かつキャッシュ設定で安全にマウント

## テスト結果・確認項目
- [x] devcontainer.jsonの構文が正しいことを確認
- [x] マウント設定が期待通りに動作することを確認
- [x] 既存の機能に影響がないことを確認

## 関連Issue / Backlog課題
なし

## 次のステップ
- レビュー後にマージ
- 必要に応じて他の開発コンテナ設定にも同様の変更を適用検討

🤖 Generated with [Claude Code](https://claude.ai/code)